### PR TITLE
Provide a smaller image (37 MB) based on Alpine Linux

### DIFF
--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -350,17 +350,17 @@ curl -sSfL ${DOCKER_HOST_IP}:8011/abc.php/ 2>&1 | grep -iF 'My hostname is web-c
 echo
 
 echo "=> Test force_ssl with virtual host"
-rm_container web-a web-b lb 
+rm_container web-a web-b lb
 docker run -d --name web-a -e HOSTNAME="web-a" -e VIRTUAL_HOST="https://web-a.org, web-a.org" -e SSL_CERT="$(awk 1 ORS='\\n' cert1.pem)" tutum/hello-world
 docker run -d --name web-b -e HOSTNAME="web-b" -e VIRTUAL_HOST="https://web-b.org, web-b.org" -e SSL_CERT="$(awk 1 ORS='\\n' cert2.pem)" -e FORCE_SSL=true tutum/hello-world
 docker run -d --name lb  --link web-a:web-a --link web-b:web-b -p 443:443 -p 80:80 haproxy
 wait_for_startup http://${DOCKER_HOST_IP}:80
-curl -sSfL --cacert ca1.pem --resolve web-a.org:443:127.0.0.1 https://web-a.org 2>&1 | grep -iF 'My hostname is web-a' > /dev/null
-curl -sSfL --cacert ca2.pem --resolve web-b.org:443:127.0.0.1 https://web-b.org 2>&1 | grep -iF 'My hostname is web-b' > /dev/null
-curl -sSfL --cacert ca1.pem --resolve web-a.org:443:127.0.0.1 --resolve web-a.org:80:127.0.0.1 http://web-a.org 2>&1 | grep -iF 'My hostname is web-a' > /dev/null
-curl -sSfL --cacert ca2.pem --resolve web-b.org:443:127.0.0.1 --resolve web-b.org:80:127.0.0.1 http://web-b.org 2>&1 | grep -iF 'My hostname is web-b' > /dev/null
-curl -sSIL --cacert ca1.pem --resolve web-a.org:443:127.0.0.1 --resolve web-a.org:80:127.0.0.1 http://web-a.org 2>&1 | grep -iF "http/1.1" | grep -v "301" > /dev/null
-curl -sSIL --cacert ca2.pem --resolve web-b.org:443:127.0.0.1 --resolve web-b.org:80:127.0.0.1 http://web-b.org 2>&1 | grep -iF '301 Moved Permanently' > /dev/null
+curl -sSfL --cacert ca1.pem --resolve web-a.org:443:${DOCKER_HOST_IP} https://web-a.org 2>&1 | grep -iF 'My hostname is web-a' > /dev/null
+curl -sSfL --cacert ca2.pem --resolve web-b.org:443:${DOCKER_HOST_IP} https://web-b.org 2>&1 | grep -iF 'My hostname is web-b' > /dev/null
+curl -sSfL --cacert ca1.pem --resolve web-a.org:443:${DOCKER_HOST_IP} --resolve web-a.org:80:${DOCKER_HOST_IP} http://web-a.org 2>&1 | grep -iF 'My hostname is web-a' > /dev/null
+curl -sSfL --cacert ca2.pem --resolve web-b.org:443:${DOCKER_HOST_IP} --resolve web-b.org:80:${DOCKER_HOST_IP} http://web-b.org 2>&1 | grep -iF 'My hostname is web-b' > /dev/null
+curl -sSIL --cacert ca1.pem --resolve web-a.org:443:${DOCKER_HOST_IP} --resolve web-a.org:80:${DOCKER_HOST_IP} http://web-a.org 2>&1 | grep -iF "http/1.1" | grep -v "301" > /dev/null
+curl -sSIL --cacert ca2.pem --resolve web-b.org:443:${DOCKER_HOST_IP} --resolve web-b.org:80:${DOCKER_HOST_IP} http://web-b.org 2>&1 | grep -iF '301 Moved Permanently' > /dev/null
 echo
 
 echo "=> Testing force_ssl without virtual host"


### PR DESCRIPTION
This is an alternative image based on Alpine Linux.
I propose to provide it via an additional tag for folks who value small image sizes.

The image size reported by `docker images` is only `37 MB` compared to the `234 MB` of the official image.

The list of changes compared to `master`:

* Use `alpine:edge` as base image.
* Use `tini` as entrypoint.
* Install the `dockercloud-haproxy` python package via GitHub url.
* Clean up obsolete installation files.
* Fix missing `${DOCKER_HOST_IP}` in the integration tests.
* Add `.dockerignore` file.

The tests ran successfully; I used the following command to run them:

```sh
docker run --rm -it \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v "$PWD:$PWD" \
  -w "$PWD" \
  -e DOCKER_HOST_IP=$(docker-machine ip) \
  blueimp/dind:1.9 \
  sh -c 'pip install websocket-client==0.32.0 six==1.9.0 && exec ./test.sh'
```

I've also set up an automated build of this alternative image on [Docker Hub](https://hub.docker.com/r/blueimp/dockercloud-haproxy) that you can try out with the following `docker-compose.yml`:

```yml
version: '2'
services:
  web:
    image: dockercloud/hello-world
  lb:
    image: blueimp/dockercloud-haproxy:1.2
    links:
      - web
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
    ports:
      - 80:80
```

 Thanks for your consideration.

