### PR TITLE
Adding Adittional Backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 
 |Environment Variable|Default|Description|
 |:-----:|:-----:|:----------|
+|ADDITIONAL_BACKENDS| |list of additional backends to balance. The format is `backend name, server name ,FORCE_SSL(True|False),host:port,options`|
 |ADDITIONAL_SERVICES| |list of additional services to balance (es: `prj1:web,prj2:sql`). Discovery will be based on `com.docker.compose.[project|service]` container labels. This environment variable only works on compose v2, and the referenced services must be on a network resolvable and accessible to this containers.|
 |BALANCE|roundrobin|load balancing algorithm to use. Possible values include: `roundrobin`, `static-rr`, `source`, `leastconn`. See:[HAProxy:balance](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-balance)|
 |CA_CERT_FILE| |the path of a ca-cert file. This allows you to mount your ca-cert file directly from a volume instead of from envvar. If set, `CA_CERT` envvar will be ignored. Possible value: `/cacerts/cert0.pem`|
@@ -182,6 +183,7 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 |EXTRA_GLOBAL_SETTINGS| |comma-separated string of extra settings, and each part will be appended to GLOBAL section in the configuration file. To escape comma, use `\,`. Possible value: `tune.ssl.cachesize 20000, tune.ssl.default-dh-param 2048`|
 |EXTRA_ROUTE_SETTINGS| |a string which is append to the each backend route after the health check, can be over written in the linked services. Possible value: "send-proxy"|
 |EXTRA_SSL_CERTS| |list of extra certificate names separated by comma, eg. `CERT1, CERT2, CERT3`. You also need to specify each certificate as separate env variables like so: `CERT1="<cert-body1>"`, `CERT2="<cert-body2>"`, `CERT3="<cert-body3>"`|
+|FORCE_DEFAULT_BACKEND| True | set the default_service as a default backend. This is useful when you have more than one backend and you don't want your default_service as a default backend    
 |HEALTH_CHECK|check|set health check on each backend route, possible value: "check inter 2000 rise 2 fall 3". See:[HAProxy:check](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-check)|
 |HTTP_BASIC_AUTH| |a comma-separated list of credentials(`<user>:<pass>`) for HTTP basic auth, which applies to all the backend routes. To escape comma, use `\,`. *Attention:* DO NOT rely on this for authentication in production|
 |MAXCONN|4096|sets the maximum per-process number of concurrent connections.|

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 
 |Environment Variable|Default|Description|
 |:-----:|:-----:|:----------|
-|ADDITIONAL_BACKENDS| |list of additional backends to balance. The format is `backend name, server name ,FORCE_SSL(True|False),host:port,options`|
+|ADDITIONAL_BACKENDS| |list of additional backends to balance. The format is `backend name, FORCE_SSL(True|False), server name, host:port, options`|
 |ADDITIONAL_SERVICES| |list of additional services to balance (es: `prj1:web,prj2:sql`). Discovery will be based on `com.docker.compose.[project|service]` container labels. This environment variable only works on compose v2, and the referenced services must be on a network resolvable and accessible to this containers.|
 |BALANCE|roundrobin|load balancing algorithm to use. Possible values include: `roundrobin`, `static-rr`, `source`, `leastconn`. See:[HAProxy:balance](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-balance)|
 |CA_CERT_FILE| |the path of a ca-cert file. This allows you to mount your ca-cert file directly from a volume instead of from envvar. If set, `CA_CERT` envvar will be ignored. Possible value: `/cacerts/cert0.pem`|

--- a/haproxy/config.py
+++ b/haproxy/config.py
@@ -28,8 +28,25 @@ def parse_extra_frontend_settings(envvars):
                     settings_dict[port] = settings
     return settings_dict
 
+# backend_name,server_name,settings,host:port
+def parse_additional_backends(additional_backend_settings):
+   additional_backends = {}
+   if not additional_backend_settings:
+     return additional_backends
+   for backend in additional_backend_settings.split(";"):
+     parts = backend.split(",")
+     service_name, backend_name, redirect, backend_desc,options = parts
+
+     if redirect=="True":
+        route = ["redirect scheme https code 301 if !{ ssl_fc }", backend_name + ' ' + backend_desc + ' ' + options]
+     else:
+        route = [backend_name + ' ' + backend_desc + ' ' + options]
+
+     additional_backends[service_name] = route
+   return additional_backends
 
 # envvar
+ADDITIONAL_BACKENDS = parse_additional_backends(os.getenv("ADDITIONAL_BACKENDS"))
 ADDITIONAL_SERVICES = os.getenv("ADDITIONAL_SERVICES")
 API_AUTH = os.getenv("DOCKERCLOUD_AUTH")
 BALANCE = os.getenv("BALANCE", "roundrobin")
@@ -44,6 +61,7 @@ EXTRA_FRONTEND_SETTINGS = parse_extra_frontend_settings(os.environ)
 EXTRA_GLOBAL_SETTINGS = os.getenv("EXTRA_GLOBAL_SETTINGS")
 EXTRA_SSL_CERT = os.getenv("EXTRA_SSL_CERTS")
 EXTRA_ROUTE_SETTINGS=os.getenv("EXTRA_ROUTE_SETTINGS", "")
+FORCE_DEFAULT_BACKEND = os.getenv("FORCE_DEFAULT_BACKEND", "True")
 HAPROXY_CONTAINER_URI = os.getenv("DOCKERCLOUD_CONTAINER_API_URI")
 HAPROXY_SERVICE_URI = os.getenv("DOCKERCLOUD_SERVICE_API_URI")
 HEALTH_CHECK = os.getenv("HEALTH_CHECK", "check inter 2000 rise 2 fall 3")

--- a/haproxy/config.py
+++ b/haproxy/config.py
@@ -28,21 +28,22 @@ def parse_extra_frontend_settings(envvars):
                     settings_dict[port] = settings
     return settings_dict
 
-# backend_name,server_name,settings,host:port
+# backend_name,FORCE_SSL,server_name,host:port, options
 def parse_additional_backends(additional_backend_settings):
    additional_backends = {}
    if not additional_backend_settings:
      return additional_backends
+
    for backend in additional_backend_settings.split(";"):
      parts = backend.split(",")
-     service_name, backend_name, redirect, backend_desc,options = parts
+     backend_name, force_ssl, server_name, host_port, options = parts
 
-     if redirect=="True":
-        route = ["redirect scheme https code 301 if !{ ssl_fc }", backend_name + ' ' + backend_desc + ' ' + options]
+     if force_ssl=="True":
+        route = ["redirect scheme https code 301 if !{ ssl_fc }", 'server ' + server_name + ' ' + host_port + ' ' + options]
      else:
-        route = [backend_name + ' ' + backend_desc + ' ' + options]
+        route = ['server ' + server_name + ' ' + host_port + ' ' + options]
 
-     additional_backends[service_name] = route
+     additional_backends[backend_name] = route
    return additional_backends
 
 # envvar

--- a/haproxy/haproxycfg.py
+++ b/haproxy/haproxycfg.py
@@ -111,7 +111,7 @@ class Haproxy(object):
             cfg_dict.update(self._config_tcp_sections())
             cfg_dict.update(self._config_frontend_sections())
             cfg_dict.update(self._config_backend_sections())
-            cfg_dict.update(self._config_adittional_backend_sections())
+            cfg_dict.update(self._config_adittional_backends_sections())
 
             cfg = prettify(cfg_dict)
             self._update_haproxy(cfg)
@@ -331,7 +331,7 @@ class Haproxy(object):
                     cfg["backend default_service"] = backend
         return cfg
 
-    def _config_adittional_backend_sections(self):
+    def _config_adittional_backends_sections(self):
         cfg = OrderedDict()
 
         if ADDITIONAL_BACKENDS:

--- a/haproxy/haproxycfg.py
+++ b/haproxy/haproxycfg.py
@@ -111,6 +111,7 @@ class Haproxy(object):
             cfg_dict.update(self._config_tcp_sections())
             cfg_dict.update(self._config_frontend_sections())
             cfg_dict.update(self._config_backend_sections())
+            cfg_dict.update(self._config_adittional_backend_sections())
 
             cfg = prettify(cfg_dict)
             self._update_haproxy(cfg)
@@ -328,4 +329,13 @@ class Haproxy(object):
                     cfg["backend SERVICE_%s" % service_alias] = backend
                 else:
                     cfg["backend default_service"] = backend
+        return cfg
+
+    def _config_adittional_backend_sections(self):
+        cfg = OrderedDict()
+
+        if ADDITIONAL_BACKENDS:
+            for key in ADDITIONAL_BACKENDS:
+                cfg["backend %s" % key] = ADDITIONAL_BACKENDS[key]
+
         return cfg

--- a/haproxy/helper/backend_helper.py
+++ b/haproxy/helper/backend_helper.py
@@ -18,6 +18,7 @@ def get_backend_section(details, routes, vhosts, service_alias, routes_added):
     route_setting = " ".join([route_health_check, extra_route_settings]).strip()
     backend_routes = get_backend_routes(route_setting, is_sticky, routes, routes_added, service_alias)
     backend.extend(backend_routes)
+
     return backend
 
 
@@ -43,7 +44,6 @@ def get_backend_routes(route_setting, is_sticky, routes, routes_added, service_a
                     backend_routes.append(" ".join(backend_route))
 
     return sorted(backend_routes)
-
 
 def get_route_health_check(details, service_alias, default_health_check):
     health_check = get_service_attribute(details, "health_check", service_alias)

--- a/haproxy/helper/frontend_helper.py
+++ b/haproxy/helper/frontend_helper.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from haproxy.config import EXTRA_BIND_SETTINGS, EXTRA_FRONTEND_SETTINGS, MONITOR_URI, MONITOR_PORT, MAXCONN, \
-    SKIP_FORWARDED_PROTO
+    SKIP_FORWARDED_PROTO, FORCE_DEFAULT_BACKEND
 
 
 def check_require_default_route(routes, routes_added):
@@ -152,7 +152,9 @@ def config_default_frontend(ssl_bind_string):
     if "80" in EXTRA_FRONTEND_SETTINGS:
         frontend.extend(EXTRA_FRONTEND_SETTINGS["80"])
 
-    frontend.append("default_backend default_service")
+    if "True" in FORCE_DEFAULT_BACKEND:
+        frontend.append("default_backend default_service")
+
     cfg["frontend default_port_80"] = frontend
 
     if ssl_bind_string:
@@ -171,7 +173,9 @@ def config_default_frontend(ssl_bind_string):
         if "443" in EXTRA_FRONTEND_SETTINGS:
             ssl_frontend.extend(EXTRA_FRONTEND_SETTINGS["443"])
 
-        ssl_frontend.append("default_backend default_service")
+        if "True" in FORCE_DEFAULT_BACKEND:
+            ssl_frontend.append("default_backend default_service")
+
         cfg["frontend default_port_443"] = ssl_frontend
 
     return cfg, monitor_uri_configured


### PR DESCRIPTION
This is a PR to add customs backends

The idea behind this is to add the possibility to segment some routes and send them to a different host outside Docker Cloud

For example

```
frontend www-https
    ...
    #docker-cloud backend routes
    acl host_api path_beg /api
    acl host_api path_beg /route1
    acl host_api path_beg /route2

    use_backend default_service if host_api
    default_backend cdn

backend default_service
    ...

backend cdn
   redirect scheme https code 301 if !{ ssl_fc }
   server s1 <some other host>:<some other port>
```

Additionally I've created a new flag called `FORCE_DEFAULT_BACKEND` that could disable the auto `default_backend` for cases like the example above

Any suggestion will be greatly appreciated
