### PR TITLE
Allow to disable basic auth for specific application

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Similar to using legacy links, here list some differences that you need to notic
 Once the stack is up, you can scale the web service using `docker-compose scale web=3`. dockercloud/haproxy will automatically reload its configuration.
 
 #### Running with Docker Compose v2 and Swarm (using envvar)
-When using links like previous section, the Docker Swarm scheduler can be too restrictive. 
-Even with overlay network, swarm (As of 1.1.0) will attempt to schedule haproxy on the same node as the linked service due to legacy links behavior. 
+When using links like previous section, the Docker Swarm scheduler can be too restrictive.
+Even with overlay network, swarm (As of 1.1.0) will attempt to schedule haproxy on the same node as the linked service due to legacy links behavior.
 This can cause unwanted scheduling patterns or errors such as "Unable to find a node fulfilling all dependencies..."
 
 Since Compose V2 allows discovery through the service names, Dockercloud haproxy only needs the links to indentify which service should be load balanced.
@@ -214,6 +214,7 @@ Settings here can overwrite the settings in HAProxy, which are only applied to t
 |GZIP_COMPRESSION_TYPE|enable gzip compression. The value of this envvar is a list of MIME types that will be compressed, possible value: `text/html text/plain text/css`|
 |HEALTH_CHECK|set health check on each backend route, possible value: "check inter 2000 rise 2 fall 3". See:[HAProxy:check](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-check)|
 |HSTS_MAX_AGE|enable HSTS. It is an integer representing the max age of HSTS in seconds, possible value: `31536000`|
+|HTTP_BASIC_AUTH_DISABLED|disable HTTP Basic Auth for this application service if global HTTP_BASIC_AUTH is set| 
 |HTTP_CHECK|enable HTTP protocol to check on the servers health, possible value: "OPTIONS * HTTP/1.1\r\nHost:\ www". See:[HAProxy:httpchk](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-option%20httpchk)|
 |OPTION|comma-separated list of HAProxy `option` entries. `option` specified here will be added to related backend or listen part, and overwrite the OPTION settings in the HAProxy container|
 |SSL_CERT|ssl cert, a pem file with private key followed by public certificate, '\n'(two chars) as the line separator|

--- a/haproxy/helper/backend_helper.py
+++ b/haproxy/helper/backend_helper.py
@@ -79,7 +79,7 @@ def get_backend_settings(details, service_alias, basic_auth):
     backend_settings.extend(get_hsts_max_age_setting(details, service_alias))
     backend_settings.extend(get_options_setting(details, service_alias))
     backend_settings.extend(get_extra_settings_setting(details, service_alias))
-    backend_settings.extend(get_basic_auth_setting(basic_auth))
+    backend_settings.extend(get_basic_auth_setting(details, service_alias, basic_auth))
 
     return backend_settings, is_sticky
 
@@ -162,9 +162,10 @@ def get_extra_settings_setting(details, service_alias):
     return setting
 
 
-def get_basic_auth_setting(basic_auth):
+def get_basic_auth_setting(details, service_alias, basic_auth):
     setting = []
-    if basic_auth:
+    is_disabled = get_service_attribute(details, 'http_basic_auth_disabled', service_alias)
+    if basic_auth and not is_disabled:
         setting.append("acl need_auth http_auth(haproxy_userlist)")
         setting.append("http-request auth realm haproxy_basic_auth if !need_auth")
     return setting

--- a/haproxy/parser/base_parser.py
+++ b/haproxy/parser/base_parser.py
@@ -188,3 +188,7 @@ class EnvParser(object):
     @staticmethod
     def parse_extra_route_settings(value):
         return value
+
+    @staticmethod
+    def parse_http_basic_auth_disabled(value):
+        return value

--- a/tests/unit/helper/test_backend_helper.py
+++ b/tests/unit/helper/test_backend_helper.py
@@ -198,7 +198,25 @@ class BackendHelperTestCase(unittest.TestCase):
         self.assertEqual([], get_extra_settings_setting(details, 'web-f'))
 
     def test_get_basic_auth_setting(self):
+        details = {'web-a': {'http_basic_auth_disabled': 'True'},
+                   'web-b': {'http_basic_auth_disabled': 'False'},
+                   'web-c': {'http_basic_auth_disabled': ''},
+                   'web-d': {}}
+
+        self.assertEqual([],
+            get_basic_auth_setting(details, 'web-a', 'something'))
+        self.assertEqual([],
+            get_basic_auth_setting(details, 'web-b', 'something'))
+        self.assertEqual(["acl need_auth http_auth(haproxy_userlist)", "http-request auth realm haproxy_basic_auth if !need_auth"],
+            get_basic_auth_setting(details, 'web-c', 'something'))
         self.assertEqual(
             ["acl need_auth http_auth(haproxy_userlist)", "http-request auth realm haproxy_basic_auth if !need_auth"],
-            get_basic_auth_setting('something'))
-        self.assertEqual([], get_basic_auth_setting(""))
+            get_basic_auth_setting(details, 'web-d', 'something'))
+        self.assertEqual(
+            ["acl need_auth http_auth(haproxy_userlist)", "http-request auth realm haproxy_basic_auth if !need_auth"],
+            get_basic_auth_setting(details, 'web-e', 'something'))
+        self.assertEqual([], get_basic_auth_setting(details, 'web-a', ''))
+        self.assertEqual([], get_basic_auth_setting(details, 'web-b', ''))
+        self.assertEqual([], get_basic_auth_setting(details, 'web-c', ''))
+        self.assertEqual([], get_basic_auth_setting(details, 'web-d', ''))
+        self.assertEqual([], get_basic_auth_setting(details, 'web-e', ''))


### PR DESCRIPTION
Set HTTP_BASIC_AUTH_DISABLED on a service to disable the basic auth.

The reason behind this is we are using this haproxy image on docker cloud for our staging environment and a basic auth is set on it.
But sometimes, we need to be able to access specific application without the basic auth being enabled on it.

The reasons the env var is named `HTTP_BASIC_AUTH_DISABLED` and not `HTTP_BASIC_AUTH_ENABLED`:
- The logic for all others boolean env var is "if set = True", it will then introduce a breaking change in the behaviour of the `HTTP_BASIC_AUTH` setting, because by default it will be not enabled for all backend routes
- One solution would be to default it to `True` if `get_service_attribute` returns `None` but then we need to be able to set it to `False` which require to use `distutils.util.strtobool` or equivalent string to bool method which make that specific env var to not comply with the general boolean env var behaviour ("if set = True")
