### PR TITLE
- Already incorporated in ADDITIONAL_BACKENDS - Add extra backend settings

### DIFF
--- a/haproxy/config.py
+++ b/haproxy/config.py
@@ -28,6 +28,21 @@ def parse_extra_frontend_settings(envvars):
                     settings_dict[port] = settings
     return settings_dict
 
+def parse_extra_backend_settings(envvars):
+    settings_dict = {}
+    if isinstance(envvars, os._Environ) or isinstance(envvars, dict):
+        backend_settings_pattern = re.compile(r"^EXTRA_BACKEND_SETTINGS_(\w+)$")
+        for k, v in envvars.iteritems():
+            match = backend_settings_pattern.match(k)
+            if match:
+                name = match.group(1).lower()
+                settings = [x.strip().replace("\,", ",") for x in re.split(r'(?<!\\),', v.strip())]
+                if name in settings_dict:
+                    settings_dict[name].extend(settings)
+                else:
+                    settings_dict[name] = settings
+    return settings_dict
+
 
 # envvar
 ADDITIONAL_SERVICES = os.getenv("ADDITIONAL_SERVICES")
@@ -41,6 +56,7 @@ DEFAULT_SSL_CERT = os.getenv("DEFAULT_SSL_CERT") or os.getenv("SSL_CERT")
 EXTRA_BIND_SETTINGS = parse_extra_bind_settings(os.getenv("EXTRA_BIND_SETTINGS"))
 EXTRA_DEFAULT_SETTINGS = os.getenv("EXTRA_DEFAULT_SETTINGS")
 EXTRA_FRONTEND_SETTINGS = parse_extra_frontend_settings(os.environ)
+EXTRA_BACKEND_SETTINGS = parse_extra_backend_settings(os.environ)
 EXTRA_GLOBAL_SETTINGS = os.getenv("EXTRA_GLOBAL_SETTINGS")
 EXTRA_SSL_CERT = os.getenv("EXTRA_SSL_CERTS")
 EXTRA_ROUTE_SETTINGS=os.getenv("EXTRA_ROUTE_SETTINGS", "")

--- a/haproxy/haproxycfg.py
+++ b/haproxy/haproxycfg.py
@@ -334,4 +334,9 @@ class Haproxy(object):
                     cfg["backend SERVICE_%s" % service_alias] = backend
                 else:
                     cfg["backend default_service"] = backend
+
+        # Add extra configuration, useful for non-dockercloud server forwarding
+        for extra_name in BackendHelper.get_extra_backend_names():
+            cfg["backend extra_%s" % extra_name] = BackendHelper.get_extra_backend_settings(extra_name)
+
         return cfg

--- a/haproxy/helper/backend_helper.py
+++ b/haproxy/helper/backend_helper.py
@@ -1,6 +1,6 @@
 import re
 
-from haproxy.config import HEALTH_CHECK, HTTP_BASIC_AUTH, EXTRA_ROUTE_SETTINGS
+from haproxy.config import HEALTH_CHECK, HTTP_BASIC_AUTH, EXTRA_ROUTE_SETTINGS, EXTRA_BACKEND_SETTINGS
 from haproxy.utils import get_service_attribute
 
 
@@ -19,6 +19,12 @@ def get_backend_section(details, routes, vhosts, service_alias, routes_added):
     backend_routes = get_backend_routes(route_setting, is_sticky, routes, routes_added, service_alias)
     backend.extend(backend_routes)
     return backend
+
+def get_extra_backend_names():
+    return EXTRA_BACKEND_SETTINGS.keys()
+
+def get_extra_backend_settings(name):
+    return EXTRA_BACKEND_SETTINGS[name]
 
 
 def get_backend_routes(route_setting, is_sticky, routes, routes_added, service_alias):


### PR DESCRIPTION
This will allow haproxy to be configured with additional backend settings without strict constraints on linked servers (f.e. when wanting to forward to external servers)

I know this might not be the best solution to this, but as I needed a solution for this issue I wanted to share mine.
