### PR TITLE
CLOUD-4195 do not return haproxy ingress network

### DIFF
--- a/haproxy/helper/swarm_mode_link_helper.py
+++ b/haproxy/helper/swarm_mode_link_helper.py
@@ -18,8 +18,9 @@ def get_swarm_mode_haproxy_id_nets(docker, haproxy_container_short_id):
         logger.info("Dockercloud haproxy is not running in a service in SwarmMode")
         return "", set()
 
-    haproxy_nets = set([network.get("NetworkID", "") for network in
-                        haproxy_container.get("NetworkSettings", {}).get("Networks", {}).values()])
+    haproxy_nets = set([network.get("NetworkID", "") for name, network in
+                        haproxy_container.get("NetworkSettings", {}).get("Networks", {}).iteritems()
+                        if name != "ingress"])
 
     return haproxy_service_id, haproxy_nets
 

--- a/tests/unit/helper/test_swarm_mode_link_helper.py
+++ b/tests/unit/helper/test_swarm_mode_link_helper.py
@@ -915,7 +915,7 @@ expected_links = expected_links = {
                                    'container_name': u'app.3.31b6fuwub6dcgdrvy0kivxvug'}}
 expected_linked_tasks = {u'7y45xdhy929wzcq94wqdqb8d3': {}, u'bbref0yvjbix87pv6xz1jc3pr': {},
                          u'31b6fuwub6dcgdrvy0kivxvug': {}}
-expected_nets = {"b951j4at14qali5nxevshec93", "0l130ctu8xay6vfft1mb4tjv0"}
+expected_nets = {"0l130ctu8xay6vfft1mb4tjv0"}
 expected_service_id = "07ql4q5a48seh1uhcr2m7ngar"
 
 


### PR DESCRIPTION
If a application publishes any port in docker v1.13, haproxy script picks the container address in ingress network, causing a network failure.

Related to https://github.com/docker/dockercloud-haproxy/issues/157