### PR TITLE
Escape the pipe in the readme mark down to render it correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Swarm Mode only settings:
 |Name|Type|Description|
 |:--:|:--:|:---------:|
 |SERVICE_PORTS|envvar|comma separated ports(e.g. 80, 8080), which are the ports you would like to expose in your application service. This envvar is swarm mode only, and it is **MUST** be set in swarm mode|
-|`com.docker.dockercloud.haproxy.deactivate=<true|false>`|label|when this label is set to true, haproxy will ignore the service. Could be useful for switching services on blue/green testing|
+|`com.docker.dockercloud.haproxy.deactivate=<true\|false>`|label|when this label is set to true, haproxy will ignore the service. Could be useful for switching services on blue/green testing|
 
 
 Check [the HAProxy configuration manual](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html) for more information on the above.


### PR DESCRIPTION
Fixes rendering in readme by escaping the pipe/vertical bar character.

Previously:
![image](https://cloud.githubusercontent.com/assets/1176703/25953499/7b5a0564-365b-11e7-8502-6358294c8852.png)

Now:
![image](https://cloud.githubusercontent.com/assets/1176703/25953506/7f4cd124-365b-11e7-9034-bcda73de7d71.png)
