### PR TITLE
Add an ACL for FORCE_SSL situation.

### DIFF
--- a/haproxy/helper/backend_helper.py
+++ b/haproxy/helper/backend_helper.py
@@ -112,7 +112,8 @@ def get_force_ssl_setting(details, service_alias):
     setting = []
     force_ssl = get_service_attribute(details, "force_ssl", service_alias)
     if force_ssl:
-        setting.append("redirect scheme https code 301 if !{ ssl_fc }")
+        setting.append("acl is_forwarded_ssl req.hdr(X-Forwarded-Proto) https")
+        setting.append("redirect scheme https code 301 if !{ ssl_fc } !is_forwarded_ssl")
     return setting
 
 

--- a/tests/unit/helper/test_backend_helper.py
+++ b/tests/unit/helper/test_backend_helper.py
@@ -137,8 +137,12 @@ class BackendHelperTestCase(unittest.TestCase):
                    'web-c': {'force_ssl': ''},
                    'web-d': {}}
 
-        self.assertEqual(["redirect scheme https code 301 if !{ ssl_fc }"], get_force_ssl_setting(details, 'web-a'))
-        self.assertEqual(["redirect scheme https code 301 if !{ ssl_fc }"], get_force_ssl_setting(details, 'web-b'))
+        self.assertEqual(["acl is_forwarded_ssl req.hdr(X-Forwarded-Proto) https",
+                          "redirect scheme https code 301 if !{ ssl_fc } !is_forwarded_ssl"],
+                         get_force_ssl_setting(details, 'web-a'))
+        self.assertEqual(["acl is_forwarded_ssl req.hdr(X-Forwarded-Proto) https",
+                          "redirect scheme https code 301 if !{ ssl_fc } !is_forwarded_ssl"],
+                         get_force_ssl_setting(details, 'web-b'))
         self.assertEqual([], get_force_ssl_setting(details, 'web-c'))
         self.assertEqual([], get_force_ssl_setting(details, 'web-d'))
         self.assertEqual([], get_force_ssl_setting(details, 'web-e'))


### PR DESCRIPTION
When haproxy behind other load balance proxy, such as Amazon ELB, Aliyun SLB. If you use ELB to terminate the SSL, and the haproxy listen on HTTP only, then it will raises the "ERR_TOO_MANY_REDIRECTS" error.

But the load balancer can pass a additional X-Forwarded-Proto header to haproxy. So, if we add an ACL to process the X-Forwarded-Proto header, then will solve the problem.

Must combine with the global env var "SKIP_FORWARDED_PROTO".

#210 